### PR TITLE
Fixed CLI shutdown code

### DIFF
--- a/src/main/java/ca/team2706/fvts/main/CLI.java
+++ b/src/main/java/ca/team2706/fvts/main/CLI.java
@@ -217,22 +217,7 @@ public class CLI implements Runnable, ActionListener {
 		if (message.equalsIgnoreCase("?shutdown")) {
 			out.println("Shutting down!");
 			out.flush();
-			String os = System.getProperty("os.name");
-			if (os.contains("Windows")) {
-				String[] args = new String[] { "cmd", "/c", "taskkill", "/f", "/t", "/im", "javaw.exe" };
-				try {
-					new ProcessBuilder(args).start();
-				} catch (IOException e) {
-					Log.e(e.getMessage(),true);
-				}
-			} else {
-				String[] args = new String[] { "/bin/bash", "-c", "sudo", "systemctl", "stop", "java" };
-				try {
-					new ProcessBuilder(args).start();
-				} catch (IOException e) {
-					Log.e(e.getMessage(),true);
-				}
-			}
+			System.exit(0);
 		}
 		if (message.equalsIgnoreCase("?logs")) {
 			for (String s : logs) {


### PR DESCRIPTION
I don't even remember why it was like that, it really should just be System.exit